### PR TITLE
Block uploads for constrained networks

### DIFF
--- a/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift
@@ -11,7 +11,7 @@ import DatadogInternal
 internal struct DataUploadConditions {
     enum Blocker {
         case battery(level: Int, state: BatteryStatus.State)
-        case constrainedNetworkUploadsDisabled
+        case lowDataModeOn
         case lowPowerModeOn
         case networkReachability(description: String)
     }
@@ -45,7 +45,7 @@ internal struct DataUploadConditions {
         }
         
         if let isConstrained = context.networkConnectionInfo?.isConstrained, isConstrained, !constrainedNetworkUploadsEnabled {
-            return [.constrainedNetworkUploadsDisabled]
+            return [.lowDataModeOn]
         }
         #endif
 

--- a/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift
@@ -11,6 +11,7 @@ import DatadogInternal
 internal struct DataUploadConditions {
     enum Blocker {
         case battery(level: Int, state: BatteryStatus.State)
+        case constrainedNetworkUploadsDisabled
         case lowPowerModeOn
         case networkReachability(description: String)
     }
@@ -22,9 +23,13 @@ internal struct DataUploadConditions {
 
     /// Battery level above which data upload can be performed.
     let minBatteryLevel: Float
+    
+    /// Blocks uploads on networks with Low Data Mode enabled when set to `false`. Defaults to `true`.
+    let constrainedNetworkUploadsEnabled: Bool
 
-    init(minBatteryLevel: Float = Constants.minBatteryLevel) {
+    init(minBatteryLevel: Float = Constants.minBatteryLevel, constrainedNetworkUploadsEnabled: Bool = true) {
         self.minBatteryLevel = minBatteryLevel
+        self.constrainedNetworkUploadsEnabled = constrainedNetworkUploadsEnabled
     }
 
     func blockersForUpload(with context: DatadogContext) -> [Blocker] {
@@ -37,6 +42,10 @@ internal struct DataUploadConditions {
         let networkIsReachable = reachability == .yes || reachability == .maybe
         if !networkIsReachable {
             blockers = [.networkReachability(description: reachability.rawValue)]
+        }
+        
+        if let isConstrained = context.networkConnectionInfo?.isConstrained, isConstrained, !constrainedNetworkUploadsEnabled {
+            return [.constrainedNetworkUploadsDisabled]
         }
         #endif
 

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -245,6 +245,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
             blockers: blockers.map {
                 switch $0 {
                 case .battery: return "low_battery"
+                case .constrainedNetworkUploadsDisabled: return "constrained_network_uploads_disabled"
                 case .lowPowerModeOn: return "lpm"
                 case .networkReachability: return "offline"
                 }
@@ -293,6 +294,8 @@ extension DataUploadConditions.Blocker: CustomStringConvertible {
         switch self {
         case let .battery(level: level, state: state):
             return "🔋 Battery state is: \(state) (\(level)%)"
+        case .constrainedNetworkUploadsDisabled:
+            return "🛜 Network is constrained and uploads are disabled for constrained networks"
         case .lowPowerModeOn:
             return "🔌 Low Power Mode is: enabled"
         case let .networkReachability(description: description):

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -245,7 +245,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
             blockers: blockers.map {
                 switch $0 {
                 case .battery: return "low_battery"
-                case .constrainedNetworkUploadsDisabled: return "constrained_network_uploads_disabled"
+                case .lowDataModeOn: return "ldm"
                 case .lowPowerModeOn: return "lpm"
                 case .networkReachability: return "offline"
                 }
@@ -294,8 +294,8 @@ extension DataUploadConditions.Blocker: CustomStringConvertible {
         switch self {
         case let .battery(level: level, state: state):
             return "🔋 Battery state is: \(state) (\(level)%)"
-        case .constrainedNetworkUploadsDisabled:
-            return "🛜 Network is constrained and uploads are disabled for constrained networks"
+        case .lowDataModeOn:
+            return "🛜 Network is in Low Data Mode and uploads are disabled for constrained networks"
         case .lowPowerModeOn:
             return "🔌 Low Power Mode is: enabled"
         case let .networkReachability(description: description):

--- a/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
+++ b/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
@@ -58,7 +58,7 @@ internal struct FeatureUpload {
                 fileReader: fileReader,
                 dataUploader: dataUploader,
                 contextProvider: contextProvider,
-                uploadConditions: DataUploadConditions(),
+                uploadConditions: DataUploadConditions(constrainedNetworkUploadsEnabled: performance.constrainedNetworkUploadsEnabled),
                 delay: DataUploadDelay(performance: performance),
                 featureName: featureName,
                 telemetry: telemetry,

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -135,49 +135,58 @@ public enum Datadog {
         ///
         /// `false` by default.
         public var backgroundTasksEnabled: Bool
+        
+        /// Allows uploads on constrained networks
+        ///
+        /// Defaults to `true` but can be overridden to block uploads on networks with "Low Data Mode" enabled
+        public var constrainedNetworkUploadsEnabled: Bool
 
         /// Creates a Datadog SDK Configuration object.
         ///
         /// - Parameters:
-        ///   - clientToken:                Either the RUM client token (which supports RUM, Logging and APM) or regular client token,
-        ///                                 only for Logging and APM.
+        ///   - clientToken:                            Either the RUM client token (which supports RUM, Logging and APM) or regular client token,
+        ///                                             only for Logging and APM.
         ///
-        ///   - env:                        The environment name which will be sent to Datadog. This can be used
-        ///                                 To filter events on different environments (e.g. "staging" or "production").
+        ///   - env:                                    The environment name which will be sent to Datadog. This can be used
+        ///                                             To filter events on different environments (e.g. "staging" or "production").
         ///
-        ///   - site:                       Datadog site endpoint, default value is `.us1`.
+        ///   - site:                                   Datadog site endpoint, default value is `.us1`.
         ///
-        ///   - service:                    The service name associated with data send to Datadog.
-        ///                                 Default value is set to application bundle identifier.
+        ///   - service:                                The service name associated with data send to Datadog.
+        ///                                             Default value is set to application bundle identifier.
         ///
-        ///   - bundle:                     The bundle object that contains the current executable.
+        ///   - bundle:                                 The bundle object that contains the current executable.
         ///
-        ///   - batchSize:                  The preferred size of batched data uploaded to Datadog servers.
-        ///                                 This value impacts the size and number of requests performed by the SDK.
-        ///                                 `.medium` by default.
+        ///   - batchSize:                              The preferred size of batched data uploaded to Datadog servers.
+        ///                                             This value impacts the size and number of requests performed by the SDK.
+        ///                                             `.medium` by default.
         ///
-        ///   - uploadFrequency:            The preferred frequency of uploading data to Datadog servers.
-        ///                                 This value impacts the frequency of performing network requests by the SDK.
-        ///                                 `.average` by default.
+        ///   - uploadFrequency:                        The preferred frequency of uploading data to Datadog servers.
+        ///                                             This value impacts the frequency of performing network requests by the SDK.
+        ///                                             `.average` by default.
         ///
-        ///   - proxyConfiguration:         A proxy configuration attributes.
-        ///                                 This can be used to a enable a custom proxy for uploading tracked data to Datadog's intake.
+        ///   - proxyConfiguration:                     A proxy configuration attributes.
+        ///                                             This can be used to a enable a custom proxy for uploading tracked data to Datadog's intake.
         ///
-        ///   - encryption:                 Data encryption to use for on-disk data persistency by providing an object
-        ///                                 complying with `DataEncryption` protocol.
+        ///   - encryption:                             Data encryption to use for on-disk data persistency by providing an object
+        ///                                             complying with `DataEncryption` protocol.
         ///
-        ///   - serverDateProvider:         A custom NTP synchronization interface.
-        ///                                 By default, the Datadog SDK synchronizes with dedicated NTP pools provided by the
-        ///                                 https://www.ntppool.org/ . Using different pools or setting a no-op `ServerDateProvider`
-        ///                                 implementation will result in desynchronization of the SDK instance and the Datadog servers.
-        ///                                 This can lead to significant time shift in RUM sessions or distributed traces.
-        ///   - backgroundTasksEnabled:     A flag that determines if `UIApplication` methods
-        ///                                 `beginBackgroundTask(expirationHandler:)` and `endBackgroundTask:`
-        ///                                 are used to perform background uploads.
-        ///                                 It may extend the amount of time the app is operating in background by 30 seconds.
-        ///                                 Tasks are normally stopped when there's nothing to upload or when encountering
-        ///                                 any upload blocker such us no internet connection or low battery.
-        ///                                 By default it's set to `false`.
+        ///   - serverDateProvider:                     A custom NTP synchronization interface.
+        ///                                             By default, the Datadog SDK synchronizes with dedicated NTP pools provided by the
+        ///                                             https://www.ntppool.org/ . Using different pools or setting a no-op `ServerDateProvider`
+        ///                                             implementation will result in desynchronization of the SDK instance and the Datadog servers.
+        ///                                             This can lead to significant time shift in RUM sessions or distributed traces.
+        ///
+        ///   - backgroundTasksEnabled:                 A flag that determines if `UIApplication` methods
+        ///                                             `beginBackgroundTask(expirationHandler:)` and `endBackgroundTask:`
+        ///                                             are used to perform background uploads.
+        ///                                             It may extend the amount of time the app is operating in background by 30 seconds.
+        ///                                             Tasks are normally stopped when there's nothing to upload or when encountering
+        ///                                             any upload blocker such us no internet connection or low battery.
+        ///                                             By default it's set to `false`.
+        ///
+        ///   - constrainedNetworkUploadsEnabled:       A flag that determines if uploads should be enabled on networks in Low Data Mode.
+        ///                                             By default it's set to `true`.
         public init(
             clientToken: String,
             env: String,
@@ -190,7 +199,8 @@ public enum Datadog {
             encryption: DataEncryption? = nil,
             serverDateProvider: ServerDateProvider? = nil,
             batchProcessingLevel: BatchProcessingLevel = .medium,
-            backgroundTasksEnabled: Bool = false
+            backgroundTasksEnabled: Bool = false,
+            constrainedNetworkUploadsEnabled: Bool = true
         ) {
             self.clientToken = clientToken
             self.env = env
@@ -204,6 +214,7 @@ public enum Datadog {
             self.serverDateProvider = serverDateProvider ?? DatadogNTPDateProvider()
             self.batchProcessingLevel = batchProcessingLevel
             self.backgroundTasksEnabled = backgroundTasksEnabled
+            self.constrainedNetworkUploadsEnabled = constrainedNetworkUploadsEnabled
         }
 
         // MARK: - Internal
@@ -539,7 +550,8 @@ extension DatadogCore {
             batchSize: debug ? .small : configuration.batchSize,
             uploadFrequency: debug ? .frequent : configuration.uploadFrequency,
             bundleType: bundleType,
-            batchProcessingLevel: configuration.batchProcessingLevel
+            batchProcessingLevel: configuration.batchProcessingLevel,
+            constrainedNetworkUploadsEnabled: configuration.constrainedNetworkUploadsEnabled
         )
         let isRunFromExtension = bundleType == .iOSAppExtension
 

--- a/DatadogCore/Sources/PerformancePreset.swift
+++ b/DatadogCore/Sources/PerformancePreset.swift
@@ -66,6 +66,7 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
     let maxUploadDelay: TimeInterval
     let uploadDelayChangeRate: Double
     let maxBatchesPerUpload: Int
+    let constrainedNetworkUploadsEnabled: Bool
 }
 
 internal extension PerformancePreset {
@@ -73,7 +74,8 @@ internal extension PerformancePreset {
         batchSize: Datadog.Configuration.BatchSize,
         uploadFrequency: Datadog.Configuration.UploadFrequency,
         bundleType: BundleType,
-        batchProcessingLevel: Datadog.Configuration.BatchProcessingLevel
+        batchProcessingLevel: Datadog.Configuration.BatchProcessingLevel,
+        constrainedNetworkUploadsEnabled: Bool = true
     ) {
         let meanFileAgeInSeconds: TimeInterval = {
             switch (bundleType, batchSize) {
@@ -116,7 +118,8 @@ internal extension PerformancePreset {
             meanFileAge: meanFileAgeInSeconds,
             minUploadDelay: minUploadDelayInSeconds,
             uploadDelayFactors: uploadDelayFactors,
-            maxBatchesPerUpload: batchProcessingLevel.maxBatchesPerUpload
+            maxBatchesPerUpload: batchProcessingLevel.maxBatchesPerUpload,
+            constrainedNetworkUploadsEnabled: constrainedNetworkUploadsEnabled
         )
     }
 
@@ -124,7 +127,8 @@ internal extension PerformancePreset {
         meanFileAge: TimeInterval,
         minUploadDelay: TimeInterval,
         uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double),
-        maxBatchesPerUpload: Int
+        maxBatchesPerUpload: Int,
+        constrainedNetworkUploadsEnabled: Bool = true
     ) {
         self.maxFileSize = 4.MB.asUInt32()
         self.maxDirectorySize = 512.MB.asUInt32()
@@ -138,6 +142,7 @@ internal extension PerformancePreset {
         self.maxUploadDelay = minUploadDelay * uploadDelayFactors.max
         self.uploadDelayChangeRate = uploadDelayFactors.changeRate
         self.maxBatchesPerUpload = maxBatchesPerUpload
+        self.constrainedNetworkUploadsEnabled = constrainedNetworkUploadsEnabled
     }
 
     func updated(with override: PerformancePresetOverride) -> PerformancePreset {
@@ -153,7 +158,8 @@ internal extension PerformancePreset {
             minUploadDelay: override.minUploadDelay ?? minUploadDelay,
             maxUploadDelay: override.maxUploadDelay ?? maxUploadDelay,
             uploadDelayChangeRate: override.uploadDelayChangeRate ?? uploadDelayChangeRate,
-            maxBatchesPerUpload: maxBatchesPerUpload
+            maxBatchesPerUpload: maxBatchesPerUpload,
+            constrainedNetworkUploadsEnabled: true
         )
     }
 }

--- a/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
+++ b/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
@@ -41,6 +41,9 @@ public struct PerformancePresetOverride {
     /// Overrides the current interval is change on successful upload. Should be less or equal `1.0`.
     /// E.g: if rate is `0.1` then `delay` will be changed by `delay * 0.1`.
     public let uploadDelayChangeRate: Double?
+    
+    /// Overrides the current upload behavior when connected to a network in Low Data Mode
+    public let constrainedNetworkUploadsEnabled: Bool?
 
     /// Initializes a new `PerformancePresetOverride` instance with the provided overrides.
     ///
@@ -53,7 +56,8 @@ public struct PerformancePresetOverride {
         maxFileSize: UInt32?,
         maxObjectSize: UInt32?,
         meanFileAge: TimeInterval? = nil,
-        uploadDelay: (initial: TimeInterval, range: Range<TimeInterval>, changeRate: Double)? = nil
+        uploadDelay: (initial: TimeInterval, range: Range<TimeInterval>, changeRate: Double)? = nil,
+        constrainedNetworkUploadsEnabled: Bool? = nil
     ) {
         self.maxFileSize = maxFileSize
         self.maxObjectSize = maxObjectSize
@@ -77,6 +81,12 @@ public struct PerformancePresetOverride {
             self.minUploadDelay = nil
             self.maxUploadDelay = nil
             self.uploadDelayChangeRate = nil
+        }
+        
+        if let constrainedNetworkUploadsEnabled {
+            self.constrainedNetworkUploadsEnabled = constrainedNetworkUploadsEnabled
+        } else {
+            self.constrainedNetworkUploadsEnabled = nil
         }
     }
 }

--- a/DatadogInternal/Sources/Upload/UploadPerformancePreset.swift
+++ b/DatadogInternal/Sources/Upload/UploadPerformancePreset.swift
@@ -20,4 +20,6 @@ public protocol UploadPerformancePreset {
     var uploadDelayChangeRate: Double { get }
     /// Number of batches to process during one upload cycle.
     var maxBatchesPerUpload: Int { get }
+    /// Enable uploads on networks in Low Data Mode. Default is `true`.
+    var constrainedNetworkUploadsEnabled: Bool { get }
 }


### PR DESCRIPTION
### What and why?

This PR adds a `constrainedNetworkUploadsDisabled` property which allows users to configure whether or not the SDK blocks uploads on constrained networks. This property defaults to `false` to keep the existing behavior. 

### How?

The SDK is already tracking whether or not the network is constrained in [NWPathMonitorPublisher](https://github.com/kmusco-foreflight/dd-sdk-ios/blob/703b477d9b0d8921a0622ba6497d66335c0dd42c/DatadogCore/Sources/Core/Context/NetworkConnectionInfoPublisher.swift#L20) and has a mechanism for blocking uploads with [DataUploadConditions.blockersForUpload()](https://github.com/kmusco-foreflight/dd-sdk-ios/blob/703b477d9b0d8921a0622ba6497d66335c0dd42c/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift#L31). This PR updates `blockersForUpload()` to check the `isConstrained` network property. If `isConstrained` is `true` and the `constrainedNetworkUploadsDisabled` parameter is `true`, the upload is blocked. 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
